### PR TITLE
Update name normalization to use NameCase library

### DIFF
--- a/AMFormsCST.Desktop/AMFormsCST.Desktop.csproj
+++ b/AMFormsCST.Desktop/AMFormsCST.Desktop.csproj
@@ -60,12 +60,14 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="Humanizer" Version="3.0.8" />
     <PackageReference Include="Lepo.i18n" Version="2.0.0" />
     <PackageReference Include="Lepo.i18n.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Lepo.i18n.Wpf" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.3" />
     <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="NameCase" Version="1.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />

--- a/AMFormsCST.Desktop/Models/Notebook/Contact.cs
+++ b/AMFormsCST.Desktop/Models/Notebook/Contact.cs
@@ -2,6 +2,7 @@
 using AMFormsCST.Core.Interfaces.Notebook;
 using AMFormsCST.Desktop.BaseClasses;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Humanizer;
 using Serilog.Context;
 using System;
 using System.Globalization;
@@ -74,7 +75,7 @@ public partial class Contact : ManagedObservableCollectionItem
     }
     partial void OnNameChanged(string value)
     {
-        Name = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value.ToLower()).Equals(value) ? value : CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value.ToLower());
+        Name = NameCase.NameCaser.ToNameCase(Name);
         OnPropertyChanged(nameof(IsBlank));
         UpdateCore();
         using (LogContext.PushProperty("ContactId", Id))


### PR DESCRIPTION
Switched contact name normalization from CultureInfo.TitleCase to NameCase.NameCaser.ToNameCase for improved accuracy. Added Humanizer and NameCase NuGet packages to project dependencies. closes #88